### PR TITLE
Add metallic noise drum

### DIFF
--- a/engine/drums/metallic.scd
+++ b/engine/drums/metallic.scd
@@ -1,21 +1,21 @@
 (
 	name: "Metallic Noise",
 	synth: {
-        arg hz = 0, vel, env;
-        var sig;
-        sig = Pulse.ar([
-		      203.52 + hz,
-		      301.77 + hz,
-		      366.31 + hz,
-		      518.19 + hz,
-		      538.75 + hz,
-		      811.16 + hz
-	      ], mul:0.15);
-	      sig = BPF.ar(sig,TRand.kr(100, 10000, env));
-	      sig = Splay.ar(sig) * env;
+	arg hz = 0, vel, env;
+	var sig;
+	sig = Pulse.ar([
+		203.52 + hz,
+		301.77 + hz,
+		366.31 + hz,
+		518.19 + hz,
+		538.75 + hz,
+		811.16 + hz
+	], mul:0.15);
+	sig = BPF.ar(sig,TRand.kr(100, 10000, env));
+	sig = Splay.ar(sig) * env;
 	},
 	controls: (
-    hz: ControlSpec(0, 2500, \exp, 0, 110, "hz"),
+		hz: ControlSpec(0, 2500, \exp, 0, 110, "hz"),
 		decay: ControlSpec(0.05, 2, \exp, 0, 0.1, "seconds"),
 		curve: ControlSpec(-20, 20, \lin, 0, 0, "exponent"),
 	)

--- a/engine/drums/metallic.scd
+++ b/engine/drums/metallic.scd
@@ -11,7 +11,7 @@
 		538.75 + hz,
 		811.16 + hz
 	], mul:0.15);
-	sig = BPF.ar(sig,TRand.kr(100, 10000, env));
+	sig = BPF.ar(sig,TRand.kr(50, 8000, env));
 	sig = Splay.ar(sig) * env;
 	},
 	controls: (

--- a/engine/drums/metallic.scd
+++ b/engine/drums/metallic.scd
@@ -1,0 +1,13 @@
+(
+	name: "Metallic Noise",
+	synth: {
+        arg vel, env;
+        var sig;
+        sig = Pulse.ar([203.52,301.77,366.31,518.19,538.75,811.16], mul:0.15);
+	      sig = Splay.ar(sig) * env;
+	},
+	controls: (
+		decay: ControlSpec(0.05, 2, \exp, 0, 0.1, "seconds"),
+		curve: ControlSpec(-20, 20, \lin, 0, 0, "exponent"),
+	)
+)

--- a/engine/drums/metallic.scd
+++ b/engine/drums/metallic.scd
@@ -1,12 +1,21 @@
 (
 	name: "Metallic Noise",
 	synth: {
-        arg vel, env;
+        arg hz = 0, vel, env;
         var sig;
-        sig = Pulse.ar([203.52,301.77,366.31,518.19,538.75,811.16], mul:0.15);
+        sig = Pulse.ar([
+		      203.52 + hz,
+		      301.77 + hz,
+		      366.31 + hz,
+		      518.19 + hz,
+		      538.75 + hz,
+		      811.16 + hz
+	      ], mul:0.15);
+	      sig = BPF.ar(sig,TRand.kr(100, 10000, env));
 	      sig = Splay.ar(sig) * env;
 	},
 	controls: (
+    hz: ControlSpec(0, 2500, \exp, 0, 110, "hz"),
 		decay: ControlSpec(0.05, 2, \exp, 0, 0.1, "seconds"),
 		curve: ControlSpec(-20, 20, \lin, 0, 0, "exponent"),
 	)


### PR DESCRIPTION
Adds a metallic noise drum built from six detuned pulse oscs, inspired by (but a poor imitation of) the metallic noise output from Verbos' Random Sampling. 