### PR TITLE
adjust overall level

### DIFF
--- a/engine/drums/metallic.scd
+++ b/engine/drums/metallic.scd
@@ -10,7 +10,7 @@
 		518.19 + hz,
 		538.75 + hz,
 		811.16 + hz
-	], mul:0.15);
+	], mul:0.23);
 	sig = BPF.ar(sig,TRand.kr(50, 8000, env));
 	sig = Splay.ar(sig) * env;
 	},


### PR DESCRIPTION
Bumps up the `mul` value for the pulse oscs from `0.15` to `0.23`